### PR TITLE
Update version in controllers

### DIFF
--- a/widget/edit.controller.js
+++ b/widget/edit.controller.js
@@ -2,11 +2,11 @@
 (function () {
   angular
     .module('cybersponse')
-    .controller('editMitreAttackSpread100Ctrl', editMitreAttackSpread100Ctrl);
+    .controller('editMitreAttackSpread101Ctrl', editMitreAttackSpread101Ctrl);
 
-  editMitreAttackSpread100Ctrl.$inject = ['$scope', '$uibModalInstance', 'config', 'ALL_RECORDS_SIZE', '$state', '$resource', 'API', 'Entity'];
+  editMitreAttackSpread101Ctrl.$inject = ['$scope', '$uibModalInstance', 'config', 'ALL_RECORDS_SIZE', '$state', '$resource', 'API', 'Entity'];
 
-  function editMitreAttackSpread100Ctrl($scope, $uibModalInstance, config, ALL_RECORDS_SIZE, $state, $resource, API, Entity) {
+  function editMitreAttackSpread101Ctrl($scope, $uibModalInstance, config, ALL_RECORDS_SIZE, $state, $resource, API, Entity) {
     $scope.cancel = cancel;
     $scope.save = save;
     $scope.config = config;

--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -2,13 +2,13 @@
 (function () {
   angular
     .module('cybersponse')
-    .controller('mitreAttackSpread100Ctrl', mitreAttackSpread100Ctrl);
+    .controller('mitreAttackSpread101Ctrl', mitreAttackSpread101Ctrl);
 
-  mitreAttackSpread100Ctrl.$inject = ['$scope', 'appModulesService', 'currentPermissionsService', 'usersService',
+  mitreAttackSpread101Ctrl.$inject = ['$scope', 'appModulesService', 'currentPermissionsService', 'usersService',
     '$state', '$filter', 'ALL_RECORDS_SIZE', 'API', '$resource', '_', '$q'
   ];
 
-  function mitreAttackSpread100Ctrl($scope, appModulesService, currentPermissionsService, usersService,
+  function mitreAttackSpread101Ctrl($scope, appModulesService, currentPermissionsService, usersService,
     $state, $filter, ALL_RECORDS_SIZE, API, $resource, _, $q) {
 
     // the relationship fields do not seem to follow a standard naming convention as seen below

--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -81,7 +81,7 @@
       }
     };
 
-    
+
     if ($scope.config.incidentsQuery != undefined && $scope.config.incidentsQuery.filters.length != 0) {
       var old_incidents_filter = {"logic": $scope.incidents.query.logic, "filters": $scope.incidents.query.filters};
       $scope.incidents.query.logic = "AND";
@@ -184,6 +184,7 @@
     $scope.related_tactics = [];
     $scope.currentUser = usersService.getCurrentUser();
     $scope.currentTheme = 'dark';
+    $scope.changeMatrix = changeMatrix;
     $scope.globalRefresh = globalRefresh;
     $scope.hide_all = false;
 
@@ -200,6 +201,10 @@
       'TA0038', 'TA0039',
       'TA0108', 'TA0104', 'TA0110', 'TA0111', 'TA0103', 'TA0102', // ics
       'TA0109', 'TA0100', 'TA0101', 'TA0107', 'TA0106', 'TA0105'];
+    $scope.enterprise_list = $scope.tactics_order.slice(0, 14);
+    $scope.mobile_list = $scope.tactics_order.slice(14, 28);
+    $scope.ics_list = $scope.tactics_order.slice(28);
+    $scope.selected_list = $scope.enterprise_list;
 
     init();
 
@@ -291,7 +296,7 @@
             angular.forEach($scope.subtechniquesRecords, function (subtechnique_record) {
               if (subtechnique_record.parentTechnique != null) { // need this check otherwise it breaks the loop
                 if (technique['@id'] == subtechnique_record.parentTechnique) {
-                  // requires subtechnique object to be cloned 
+                  // requires subtechnique object to be cloned
                   // otherwise clicking on one toggle shows/hides alerts and incidents across all duplicates
                   technique._subtechniques.push(structuredClone(subtechnique_record));
                 }
@@ -526,6 +531,18 @@
         previousParams: JSON.stringify($state.params),
       };
       $state.go(state, params);
+    }
+
+    function changeMatrix(selectedMatrix) {
+      if (selectedMatrix === 'mobile') {
+        $scope.selected_list = $scope.mobile_list;
+      }
+      else if (selectedMatrix === 'ics') {
+        $scope.selected_list = $scope.ics_list;
+      }
+      else {
+        $scope.selected_list = $scope.enterprise_list;
+      }
     }
 
     function globalRefresh() {

--- a/widget/view.html
+++ b/widget/view.html
@@ -3,8 +3,18 @@
   <div class="display-flex-space-between margin-chart">
     <div class="padding-right-0 padding-left-0 widget-dashboard-title-width"
       data-ng-class="(page === 'dashboard' || page === 'reporting') ? 'widget-dashboard-title-width' : 'widget-title-width'">
-      <h5 class="margin-top-0 margin-bottom-0 text-overflow ng-binding">{{ config.title ? config.title : 'MITRE ATT&CK
-        Alert/Incident Spread' }}</h5>
+      <h5 class="margin-top-0 margin-bottom-0 text-overflow ng-binding"><span class="pull-left padding-top-sm">{{ config.title ? config.title : 'MITRE ATT&CK
+        Alert/Incident Spread' }}&nbsp;&nbsp;&nbsp;
+        </span>
+        <span class="pull-left">
+          <select data-ng-readonly="disabled" data-ng-model="selectedMatrix" class="form-control ng-pristine ng-valid ng-empty input-sm ng-touched" data-ng-change="changeMatrix(selectedMatrix)" data-ng-class="::{'input-big': size === 'large', 'input-sm': size === 'small'}" aria-invalid="false">
+            <option value="" disabled selected>Select Matrix</option>
+            <option value="enterprise">Enterprise</option>
+            <option value="mobile">Mobile</option>
+            <option value="ics">ICS</option>
+          </select>
+        </span>
+      </h5>
     </div>
     <div class="padding-left-0 margin-top-8 padding-top-5 pull-left" data-ng-show="detail_display">
       <span class="fa btn btn-sm" data-ng-class="{'hover':isOpen}" data-ng-click="globalRefresh()" role="button"
@@ -24,7 +34,7 @@
             <tr>
               <td class="mitre-techniques-count padding-top-sm padding-left-sm padding-right-sm"
                 data-ng-repeat="tactic in tacticsRecords | orderBy:'_order_key'"
-                data-ng-hide="(tactic.techniques.length == 0 && config.hideTactics) || (tactic._hidden_techniques_count == tactic.techniques.length && config.hideParentTactics && !tactic._toggled) || (detail_display && !tactic._toggled_detail)">
+                data-ng-hide="(tactic.techniques.length == 0 && config.hideTactics) || (tactic._hidden_techniques_count == tactic.techniques.length && config.hideParentTactics && !tactic._toggled) || (detail_display && !tactic._toggled_detail) || (selected_list.indexOf(tactic.mitreId) === -1)">
                 {{ tactic.techniques.length }}
                 {{ tactic.techniques.length === 1 ? 'technique' : 'techniques' }}
               </td>
@@ -32,7 +42,7 @@
             <tr>
               <td class="mitre-tactics-cells padding-bottom-sm padding-left-sm padding-right-sm"
                 data-ng-repeat="tactic in tacticsRecords | orderBy:'_order_key'"
-                data-ng-hide="(tactic.techniques.length == 0 && config.hideTactics) || (tactic._hidden_techniques_count == tactic.techniques.length && config.hideParentTactics && !tactic._toggled) || (detail_display && !tactic._toggled_detail)">
+                data-ng-hide="(tactic.techniques.length == 0 && config.hideTactics) || (tactic._hidden_techniques_count == tactic.techniques.length && config.hideParentTactics && !tactic._toggled) || (detail_display && !tactic._toggled_detail) || (selected_list.indexOf(tactic.mitreId) === -1)">
                 <div class="div-style">
                   <a href="" data-ng-click="openRecord(tactics.module, tactic['@id'])" data-tooltip-placement="top"
                     data-uib-tooltip="{{tactic.mitreId}}" data-tooltip-append-to-body="true">{{ tactic.name }}</a>
@@ -43,7 +53,7 @@
           <tbody data-ng-class="currentTheme == 'light' ? 'mitre-techniques-light' : 'mitre-techniques'">
             <tr>
               <td class="padding-sm" data-ng-repeat="tactic in tacticsRecords | orderBy:'_order_key'"
-                data-ng-hide="(tactic.techniques.length == 0 && config.hideTactics) || (tactic._hidden_techniques_count == tactic.techniques.length && config.hideParentTactics && !tactic._toggled) || (detail_display && !tactic._toggled_detail)">
+                data-ng-hide="(tactic.techniques.length == 0 && config.hideTactics) || (tactic._hidden_techniques_count == tactic.techniques.length && config.hideParentTactics && !tactic._toggled) || (detail_display && !tactic._toggled_detail) || (selected_list.indexOf(tactic.mitreId) === -1)">
                 <table class="inner-mitre-table" width="100%">
                   <tr data-ng-repeat="technique in tactic.techniques">
                     <td


### PR DESCRIPTION
Updates:
- Updated widget version in controller files
- Added a new dropdown field to allow users to change which MITRE matrix is being displayed
![image](https://github.com/fortinet-fortisoar/widget-mitre-attack-spread/assets/38052663/704ff991-b404-4e3f-a193-cc1c228843cc)

Tests:
- Widget upload/install ✅ 
- Widget edit settings ✅ 
- Widget initial load ✅ 
- Enterprise matrix is the default selected matrix ✅ 
- Enterprise records are loading properly by default ✅ 
- Change MITRE matrix to enterprise and ensure only enterprise records are shown ✅ 
- Change MITRE matrix to mobile and ensure only mobile records are shown ✅ 
- Change MITRE matrix to ICS and ensure only ICS records are shown ✅ 
