### PR TITLE
[0985050/0985037]- null severity handled & technique count updated

### DIFF
--- a/widget/info.json
+++ b/widget/info.json
@@ -3,7 +3,7 @@
     "title": "MITRE ATT&CK Alert Incident Spread",
     "subTitle": "Detailed table view of Alerts and Incidents linked to MITRE ATT&CK records",
     "version": "1.0.1",
-    "published_date": "1704460365",
+    "published_date": "1704797732",
     "metadata": {
         "help_online":"https://github.com/fortinet-fortisoar/widget-mitre-attack-spread/blob/release/1.0.1/README.md",
         "description": "Provides a consolidated look into Alert and Incident threats under MITRE ATT&CK records. Requires MITRE ATT&CK Enrichment Framework installed and MITRE ATT&CK records ingested into FortiSOAR via MITRE ATT&CK Connector.",

--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -511,9 +511,9 @@
     function getSeverity(record) {
       var severity_value = 'None';
       var color_value = { color: 'white' };
-      severity_value = record.severity.itemValue;
+      severity_value = record.severity ? record.severity.itemValue : 'None'; //null severity throws error 
       color_value = {
-        'background-color': record.severity.color,
+        'background-color': record.severity ? record.severity.color : 'transparent', //null severity throws error 
         'padding': '2px'
       };
       return [severity_value, color_value];

--- a/widget/view.html
+++ b/widget/view.html
@@ -35,8 +35,8 @@
               <td class="mitre-techniques-count padding-top-sm padding-left-sm padding-right-sm"
                 data-ng-repeat="tactic in tacticsRecords | orderBy:'_order_key'"
                 data-ng-hide="(tactic.techniques.length == 0 && config.hideTactics) || (tactic._hidden_techniques_count == tactic.techniques.length && config.hideParentTactics && !tactic._toggled) || (detail_display && !tactic._toggled_detail) || (selected_list.indexOf(tactic.mitreId) === -1)">
-                {{ tactic.techniques.length }}
-                {{ tactic.techniques.length === 1 ? 'technique' : 'techniques' }}
+                {{ tactic.techniques.length - tactic._hidden_techniques_count}}
+                {{ (tactic.techniques.length - tactic._hidden_techniques_count === 1) || (tactic.techniques.length - tactic._hidden_techniques_count === 0) ? 'technique' : 'techniques' }}
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
#### Descriptions:
https://mantis.fortinet.com/bug_view_page.php?bug_id=0985050 
<img width="1702" alt="Screenshot 2024-01-09 at 4 33 10 PM" src="https://github.com/fortinet-fortisoar/widget-mitre-attack-spread/assets/92782495/03d78218-ccf8-4905-b0f8-d13cf0af1e46">

https://mantis.fortinet.com/bug_view_page.php?bug_id=0985037


#### Fix:
0985050 - group based filter was not updating the technique count
0985037 - null severity check applied in getSeverity function

<img width="1705" alt="Screenshot 2024-01-09 at 3 56 53 PM" src="https://github.com/fortinet-fortisoar/widget-mitre-attack-spread/assets/92782495/35ffee1f-a32c-4307-accc-9b7ef32c3e3a">
